### PR TITLE
Show thread feedback link

### DIFF
--- a/tradefeedback.php
+++ b/tradefeedback.php
@@ -85,13 +85,25 @@ function trader_give_rep($uid=1)
     }
     else
     {
+        // Check if we have a thread id
+        $tid = intval($mybb->input['tid']);
+        if($tid) {
+            $threadlink_value = $tid;
+            $query = $db->simple_select("threads","subject","tid=$tid");
+            $thread_subject = $db->fetch_field($query,"subject");
+            $breadcrumb = " for Thread: ".$thread_subject;
+        }
+        else {
+            $threadlink_value = "";
+        }
+
         // Get the member username for confirmation
         $query = $db->simple_select("users", "uid, username", "uid=$uid");
         $member = $db->fetch_array($query);
 		$member['username'] = htmlspecialchars_uni($member['username']);
         add_breadcrumb($member['username'] . "'s Profile", get_profile_link($uid));
         add_breadcrumb($member['username'] . "'s Reputations", "tradefeedback.php?action=view&uid=$uid");
-        add_breadcrumb("Giving Reputation", "tradefeedback.php?action=give&uid=$uid");
+        add_breadcrumb("Giving Reputation".$breadcrumb, "tradefeedback.php?action=give&uid=$uid");
 		$feedback = array('comments' => htmlspecialchars_uni($mybb->input['comments']));
         eval("\$tradefeedbackform = \"".$templates->get("tradefeedback_give_form")."\";");
         output_page($tradefeedbackform);


### PR DESCRIPTION
This commit adds the ability to award feedback to the author of a thread by clicking on a link at the bottom of the show thread template. When clicked, it will autofill in the thread ID value in the feedback form and provides the thread's title in the breadcrumb navigation. If awarding feedback from a user's profile, it does not fill in the thread URL field.

![screen shot 2015-06-30 at 1 05 00 pm](https://cloud.githubusercontent.com/assets/1896496/8439220/91aba7d2-1f38-11e5-87c0-45a7d177fc3e.png)
![screen shot 2015-06-30 at 1 05 09 pm](https://cloud.githubusercontent.com/assets/1896496/8439221/91bbca9a-1f38-11e5-943b-b688031640da.png)
