### PR TITLE
Updated feedback link from thread & URL parser

### DIFF
--- a/inc/languages/english/tradefeedback.lang.php
+++ b/inc/languages/english/tradefeedback.lang.php
@@ -1,3 +1,4 @@
 <?php
 $l['myalerts_tradefeedback'] = '{1} gave you feedback.';
 $l['myalerts_setting_tradefeedback'] = 'Receive alert when you receive feedback?';
+$l['tradefeedback_report_info'] = '<a href="{1}">Feedback</a> from {2} on {3}\'s profile';

--- a/inc/plugins/trader.php
+++ b/inc/plugins/trader.php
@@ -9,6 +9,7 @@
     $plugins->add_hook("fetch_wol_activity_end", "trader_wol");
     $plugins->add_hook("build_friendly_wol_location_end", "trader_build_friendly_location");
     $plugins->add_hook("global_start", "trader_alertregister");
+    $plugins->add_hook('modcp_reports_report', 'trader_modcp_reports_report');
 
     function trader_info()
     {
@@ -475,6 +476,26 @@ $new_template['tradefeedback_postbit_link'] = '<a href="tradefeedback.php?action
 
             }
         }
+    }
+
+    // Report Center Integration
+    function trader_modcp_reports_report()
+    {
+        global $report;
+
+        if($report['type'] != 'tradefeedback')
+        {
+            return;
+        }
+
+        global $mybb, $reputation_link, $bad_user, $lang, $good_user, $usercache, $report_data;
+
+        $user = get_user($report['id3']);
+
+        $reputation_link = $mybb->settings['bburl']."/tradefeedback.php?action=view&uid={$user['uid']}&amp;fid={$report['id']}";
+        $bad_user = build_profile_link($usercache[$report['id2']]['username'], $usercache[$report['id2']]['uid']);
+        $good_user = build_profile_link($user['username'], $user['uid']);
+        $report_data['content'] = $lang->sprintf($lang->tradefeedback_report_info, $reputation_link, $bad_user, $good_user);
     }
 
 ?>

--- a/inc/plugins/trader.php
+++ b/inc/plugins/trader.php
@@ -8,7 +8,6 @@
     $plugins->add_hook("usercp_start", "trader_usercp");
     $plugins->add_hook("fetch_wol_activity_end", "trader_wol");
     $plugins->add_hook("build_friendly_wol_location_end", "trader_build_friendly_location");
-    $plugins->add_hook("showthread_end", "trader_showthread");
     $plugins->add_hook("global_start", "trader_alertregister");
 
     function trader_info()
@@ -261,7 +260,7 @@ $new_template['tradefeedback_view_rep'] = '<tr class="trow">
 <td class="{$tdclass}">{$report}{$modbit}<br /></td>
 </tr>';
 
-$new_template['tradefeedback_showthread_link'] = '<li style="background-image: url(../../../images/buttons_sprite.png); background-repeat: no-repeat;background-position: 0 -20px;"><a href="tradefeedback.php?action=give&amp;uid={$thread[\'uid\']}&amp;tid={$tid}">Leave feedback for {$thread[\'username\']}</a></li>';
+$new_template['tradefeedback_postbit_link'] = '<a href="tradefeedback.php?action=give&amp;uid={$post[\'uid\']}&amp;tid={$post[\'tid\']}" title="Give Feedback" class="postbit_tradefeedback"><span>Give Feedback</span></a>';
 
         foreach($new_template as $title => $template)
 	    {
@@ -271,7 +270,8 @@ $new_template['tradefeedback_showthread_link'] = '<li style="background-image: u
 
         // Add Trade Feedback link to showthread template
         include MYBB_ROOT."/inc/adminfunctions_templates.php";
-        find_replace_templatesets("showthread", "#".preg_quote('{$add_remove_subscription_text}</a></li>')."#i", '{$add_remove_subscription_text}</a></li>\n{$tradefeedbacklink}');
+        find_replace_templatesets("postbit", "#".preg_quote('{$post[\'button_rep\']}')."#i", '{$post[\'button_rep\']}{$post[\'button_tradefeedback\']}');
+        find_replace_templatesets("postbit_classic", "#".preg_quote('{$post[\'button_rep\']}')."#i", '{$post[\'button_rep\']}{$post[\'button_tradefeedback\']}');
     }
 
     function trader_deactivate()
@@ -282,7 +282,8 @@ $new_template['tradefeedback_showthread_link'] = '<li style="background-image: u
 
         // Remove Trade Feedback Link from showthread template
         include MYBB_ROOT."/inc/adminfunctions_templates.php";
-        find_replace_templatesets("showthread", "#".preg_quote('{$tradefeedbacklink}')."#i", '', 0);
+        find_replace_templatesets("postbit", "#".preg_quote('{$post[\'button_tradefeedback\']}')."#i", '', 0);
+        find_replace_templatesets("postbit_classic", "#".preg_quote('{$post[\'button_tradefeedback\']}')."#i", '', 0);
     }
 
     function trader_uninstall()
@@ -311,8 +312,17 @@ $new_template['tradefeedback_showthread_link'] = '<li style="background-image: u
 
     function trader_postbit(&$post)
     {
+        global $mybb, $templates;
+
         $post['totalrep'] = $post['posreps'] - $post['negreps'];
         $post['repcount'] = $post['posreps'] + $post['neutreps'] + $post['negreps'];
+
+        // Feedback Button
+        $post['button_tradefeedback'] = '';
+        if($mybb->user['uid'] && !$mybb->user['isbannedgroup'] && $mybb->user['uid'] != $post['uid'])
+        {
+            eval("\$post['button_tradefeedback'] = \"".$templates->get("tradefeedback_postbit_link")."\";");
+        }
     }
 
     function trader_member_profile()
@@ -406,16 +416,6 @@ $new_template['tradefeedback_showthread_link'] = '<li style="background-image: u
 		{
 			$pminfo = $pmhandler->insert_pm();
 		}
-    }
-
-    // Show feedback link in show thread
-    function trader_showthread() {
-        global $mybb, $templates, $tradefeedbacklink, $tid, $thread;
-        $tradefeedbacklink = '';
-        if($mybb->user['uid'] && !$mybb->user['isbannedgroup'])
-        {
-            eval("\$tradefeedbacklink = \"".$templates->get("tradefeedback_showthread_link")."\";");
-        }
     }
 
     // MyAlerts Formatter Register

--- a/tradefeedback.php
+++ b/tradefeedback.php
@@ -89,7 +89,7 @@ function trader_give_rep($uid=1)
         // Check if we have a thread id
         $tid = intval($mybb->input['tid']);
         if($tid) {
-            $threadlink_value = $tid;
+            $threadlink_value = $mybb->settings['bburl']."/".get_thread_link($tid);
             $query = $db->simple_select("threads","subject","tid=$tid");
             $thread_subject = $db->fetch_field($query,"subject");
             $breadcrumb = " for Thread: ".$thread_subject;

--- a/tradefeedback.php
+++ b/tradefeedback.php
@@ -324,16 +324,19 @@ function trader_report($fid)
     $userid = $feedback['receiver'];
     if($mybb->request_method == "post" && verify_post_check($mybb->input['my_post_key']))
     {
-        $emailmessage = "The following feedback has been reported by " . $mybb->user['username']. ":\n<a href=\"".$mybb->settings['bburl']."/tradefeedback.php?action=view&uid=".$feedback['receiver']."&fid=$fid\"\nReason:".htmlspecialchars_uni($mybb->input['reason']);
-        // Now fetch the global mods
-        $query =$db->query("SELECT u.email, ug.gid FROM " . TABLE_PREFIX . "users u
-        LEFT JOIN " . TABLE_PREFIX ."usergroups ug ON(u.usergroup=ug.gid)
-        WHERE ug.canmodcp=1 AND ug.issupermod=1");
-        while($moderator = $db->fetch_array($query))
-        {
-            my_mail($moderator['email'], "Reported Reputation on " . $mybb->settings['bbname'], $emailmessage);
-        }
+        // Report Center Integration
+        require_once MYBB_ROOT.'inc/functions_modcp.php';
+        $new_report = array(
+            'id' => $fid, // Feedback ID
+            'id2' => $mybb->user['uid'], // id2 is the user who gave the feedback
+            'id3' => $feedback['receiver'], // id3 is the user who received the feedback
+            'uid' => $mybb->user['uid'],
+            'reason' => htmlspecialchars_uni($mybb->input['reason'])
+        );
+        add_report($new_report, "tradefeedback");
+
         $db->write_query("UPDATE ". TABLE_PREFIX . "trade_feedback SET reported=1 WHERE fid=$fid");
+
         $url = $mybb->settings['bburl'] . "/tradefeedback.php?action=view&uid=$userid";
         $message = "The rep has been reported.";
         redirect($url, $message);


### PR DESCRIPTION
- Changed give thread feedback to thread author link to a postbit button for all participants in a thread.
- When giving feedback directly from the thread, it will autofill the full URL instead of just the thread ID.

![screen shot 2015-07-14 at 3 32 55 pm](https://cloud.githubusercontent.com/assets/1896496/8682922/a4927b5e-2a3d-11e5-8818-e761a8e14d94.png)
![screen shot 2015-07-14 at 3 32 37 pm](https://cloud.githubusercontent.com/assets/1896496/8682923/a49dcea0-2a3d-11e5-89ef-4f47d444b64e.png)
